### PR TITLE
fix: Frame Divider now only runs when in use

### DIFF
--- a/addons/force_directed_graph/force_directed_graph.gd
+++ b/addons/force_directed_graph/force_directed_graph.gd
@@ -51,26 +51,27 @@ func _process(delta: float):
 	if Engine.is_editor_hint() and not simulate_in_editor:
 		return
 	
-	# Every 10 frames, check if a node has been moved, by taking the difference of the position delta and the accumulated velocity.
-	# This makes it update quicker if you move a node in the editor or set its position,
-	# especially if it had a very high frame_divide, which would otherwise make it take up to that many frames before any update happens.
-	if frames_since_calculation % 10 == 0:
-		for node in nodes:
-			var move_length = ((node.position - node.last_position) - node.last_applied_movement).length()
-			if move_length > 1:
-				frame_divide *= (0.5 / (1 + 0.01 * move_length))
-			node.last_applied_movement = Vector2.ZERO
-			node.last_position = node.position
-	
-	if frames_since_calculation < frame_divide:
-		# Skipped frame
-		frames_since_calculation += 1
-		# Update force scale with a value that decreases as the previous value gets larger. this prevents weird behavior at very slow update rates
-		frame_divide_force_compenstion += (1 / (1 + 0.2 * (frame_divide_force_compenstion - 1)))
-		return
-	else:
-		# Update frame
-		frames_since_calculation = 1
+	if auto_frame_divide:
+		# Every 10 frames, check if a node has been moved, by taking the difference of the position delta and the accumulated velocity.
+		# This makes it update quicker if you move a node in the editor or set its position,
+		# especially if it had a very high frame_divide, which would otherwise make it take up to that many frames before any update happens.
+		if frames_since_calculation % 10 == 0:
+			for node in nodes:
+				var move_length = ((node.position - node.last_position) - node.last_applied_movement).length()
+				if move_length > 1:
+					frame_divide *= (0.5 / (1 + 0.01 * move_length))
+				node.last_applied_movement = Vector2.ZERO
+				node.last_position = node.position
+		
+		if frames_since_calculation < frame_divide:
+			# Skipped frame
+			frames_since_calculation += 1
+			# Update force scale with a value that decreases as the previous value gets larger. this prevents weird behavior at very slow update rates
+			frame_divide_force_compenstion += (1 / (1 + 0.2 * (frame_divide_force_compenstion - 1)))
+			return
+		else:
+			# Update frame
+			frames_since_calculation = 1
 	
 	# Total force applied this frame
 	var total_force: float = 0


### PR DESCRIPTION
i didn't notice any issues but i think this is the proper way to do things. just adds one if block checking for if auto frame divide is enabled that i forgot previously